### PR TITLE
Common Identity addSorting

### DIFF
--- a/src/Common/Identity.php
+++ b/src/Common/Identity.php
@@ -219,7 +219,9 @@ class Identity implements IdentityInterface
      */
     public function addSorting($fieldName, Sort $sorting)
     {
-        $this->sorting[$fieldName] = $sorting;
+        if ($fieldName !== null) {
+            $this->sorting[$fieldName] = $sorting;
+        }
         return $this;
     }
 

--- a/src/Common/Identity.php
+++ b/src/Common/Identity.php
@@ -217,7 +217,7 @@ class Identity implements IdentityInterface
      * @param Sort $sorting
      * @return $this
      */
-    protected function addSorting($fieldName, Sort $sorting)
+    public function addSorting($fieldName, Sort $sorting)
     {
         $this->sorting[$fieldName] = $sorting;
         return $this;

--- a/tests/unit/src/Common/IdentityTest.php
+++ b/tests/unit/src/Common/IdentityTest.php
@@ -156,12 +156,15 @@ class IdentityTest extends PHPUnit_Framework_TestCase
     {
         $this->assertInstanceOf(\G4\DataMapper\Common\Identity::class, $this->identity->sortAscending('name'));
         $this->assertInstanceOf(\G4\DataMapper\Common\Identity::class, $this->identity->sortDescending('ts'));
+        $sortStub = $this->getMockBuilder(\G4\DataMapper\Common\Selection\Sort::class)->disableOriginalConstructor()->getMock();
+        $this->assertInstanceOf(\G4\DataMapper\Common\Identity::class, $this->identity->addSorting('sortStub', $sortStub));
 
         $sorting = $this->identity->getSorting();
 
-        $this->assertEquals(2, count($sorting));
+        $this->assertEquals(3, count($sorting));
         $this->assertInstanceOf(\G4\DataMapper\Common\Selection\Sort::class, $sorting['name']);
         $this->assertInstanceOf(\G4\DataMapper\Common\Selection\Sort::class, $sorting['ts']);
+        $this->assertInstanceOf(\G4\DataMapper\Common\Selection\Sort::class, $sorting['sortStub']);
     }
 
     public function testGrouping()

--- a/tests/unit/src/Common/IdentityTest.php
+++ b/tests/unit/src/Common/IdentityTest.php
@@ -158,6 +158,7 @@ class IdentityTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf(\G4\DataMapper\Common\Identity::class, $this->identity->sortDescending('ts'));
         $sortStub = $this->getMockBuilder(\G4\DataMapper\Common\Selection\Sort::class)->disableOriginalConstructor()->getMock();
         $this->assertInstanceOf(\G4\DataMapper\Common\Identity::class, $this->identity->addSorting('sortStub', $sortStub));
+        $this->assertInstanceOf(\G4\DataMapper\Common\Identity::class, $this->identity->addSorting(null, $sortStub));
 
         $sorting = $this->identity->getSorting();
 


### PR DESCRIPTION
addSorting() method is now public to be able to assign sort instances directly to the identity.