### PR TITLE
Fixing php7: count(): Parameter must be an array or an object that implements Countable

### DIFF
--- a/src/Engine/Elasticsearch/ElasticsearchSelectionFactory.php
+++ b/src/Engine/Elasticsearch/ElasticsearchSelectionFactory.php
@@ -22,6 +22,10 @@ class ElasticsearchSelectionFactory implements SelectionFactoryInterface
     {
         $fieldNames = $this->identity->getFieldNames();
 
+        if (!is_array($fieldNames)) {
+            return [];
+        }
+
         return count($fieldNames) === 0
             ? []
             : $fieldNames;


### PR DESCRIPTION
Fixing php7: count(): Parameter must be an array or an object that implements Countable Countable g4/data-mapper/src/Engine/Elasticsearch/ElasticsearchSelectionFactory.php#25