### PR TITLE
Cannot redeclare G4\DataMapper\Common\Identity::missing()

### DIFF
--- a/src/Common/Identity.php
+++ b/src/Common/Identity.php
@@ -227,30 +227,6 @@ class Identity implements IdentityInterface
     }
 
     /**
-     * @param $value
-     * @return $this
-     * @throws InvalidValueTypeException
-     */
-    public function missing($value)
-    {
-        $this->arrayException($value);
-        $this->operator(Operator::MISSING, new SingleValue($value));
-        return $this;
-    }
-
-    /**
-     * @param $value
-     * @return $this
-     * @throws InvalidValueTypeException
-     */
-    public function exists($value)
-    {
-        $this->arrayException($value);
-        $this->operator(Operator::EXISTS, new SingleValue($value));
-        return $this;
-    }
-
-    /**
      * @param string $fieldName
      * @param Sort $sorting
      * @return $this


### PR DESCRIPTION
Please publish 1.58.2.