### PR TITLE
remove underscore. it should stay as it is. Make sure search results …

### DIFF
--- a/src/Engine/Elasticsearch/Operators/MultiLikeCIOperator.php
+++ b/src/Engine/Elasticsearch/Operators/MultiLikeCIOperator.php
@@ -26,6 +26,6 @@ class MultiLikeCIOperator extends LikeCIOperator implements QueryOperatorInterfa
 
     private function formatValue(SingleValue $value)
     {
-        return new SingleValue(str_replace(["-","_"," "], "* *", $value));
+        return new SingleValue(str_replace([" ","-"], "* AND *", $value));
     }
 }

--- a/tests/unit/src/Engine/Elasticsearch/ElasticsearchComparisonFormatterTest.php
+++ b/tests/unit/src/Engine/Elasticsearch/ElasticsearchComparisonFormatterTest.php
@@ -188,7 +188,7 @@ class ElasticsearchComparisonFormatterTest extends \PHPUnit_Framework_TestCase
             ->method('getSymbol')
             ->willReturn(Operator::MULTI_LIKE_CI);
 
-        $this->assertEquals(['query_string' => ['query' => 'username:(*my** **name* *is** **rio*)']], $this->comparisonFormatter->format('username', $this->operatorMock, new SingleValue('my_name is-rio')));
+        $this->assertEquals(['query_string' => ['query' => 'username:(*my_name* AND *is* AND *rio*)']], $this->comparisonFormatter->format('username', $this->operatorMock, new SingleValue('my_name is-rio')));
     }
 
     public function testLikeCIVersion7()


### PR DESCRIPTION
…contain all search params